### PR TITLE
Feature/#12 - SearchRepoViewController 테이블뷰 구현(실제 데이터로)

### DIFF
--- a/GitHubSearchApp.xcodeproj/project.pbxproj
+++ b/GitHubSearchApp.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		BD2E244229000FD9003513B0 /* Property.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2E244129000FD9003513B0 /* Property.swift */; };
 		BD33FB9528FEBB0D00F42776 /* APIEndpoints.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD33FB9428FEBB0D00F42776 /* APIEndpoints.swift */; };
 		BD33FB9728FEC5CE00F42776 /* MockData.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD33FB9628FEC5CE00F42776 /* MockData.swift */; };
+		BD7A22C529027708006AFC5C /* MySection.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD7A22C429027708006AFC5C /* MySection.swift */; };
 		BDBFB70128FD9BD90071FA1C /* SearchRepoRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDBFB70028FD9BD90071FA1C /* SearchRepoRequestDTO.swift */; };
 		BDC09EBE28FCDA950024507F /* Endpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDC09EBD28FCDA940024507F /* Endpoint.swift */; };
 		BDC09EC028FD20AD0024507F /* Requestable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDC09EBF28FD20AD0024507F /* Requestable.swift */; };
@@ -62,6 +63,7 @@
 		BD2E244129000FD9003513B0 /* Property.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Property.swift; sourceTree = "<group>"; };
 		BD33FB9428FEBB0D00F42776 /* APIEndpoints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIEndpoints.swift; sourceTree = "<group>"; };
 		BD33FB9628FEC5CE00F42776 /* MockData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockData.swift; sourceTree = "<group>"; };
+		BD7A22C429027708006AFC5C /* MySection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MySection.swift; sourceTree = "<group>"; };
 		BDBFB70028FD9BD90071FA1C /* SearchRepoRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchRepoRequestDTO.swift; sourceTree = "<group>"; };
 		BDC09EBD28FCDA940024507F /* Endpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Endpoint.swift; sourceTree = "<group>"; };
 		BDC09EBF28FD20AD0024507F /* Requestable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Requestable.swift; sourceTree = "<group>"; };
@@ -149,6 +151,7 @@
 				BD0A633D28F7E25E00C080A5 /* TabBarController.swift */,
 				BD0A634428F7EEE400C080A5 /* SearchRepo */,
 				BD0A634528F7EEF000C080A5 /* FavoriteRepo */,
+				BD7A22C429027708006AFC5C /* MySection.swift */,
 			);
 			path = Presentation;
 			sourceTree = "<group>";
@@ -492,6 +495,7 @@
 			files = (
 				BD0A634228F7E32700C080A5 /* FavoriteRepoViewController.swift in Sources */,
 				BD33FB9528FEBB0D00F42776 /* APIEndpoints.swift in Sources */,
+				BD7A22C529027708006AFC5C /* MySection.swift in Sources */,
 				BDC09EC228FD228C0024507F /* NetworkError.swift in Sources */,
 				BDC09EFB28FD56CA0024507F /* SearchRepoResponseDTO.swift in Sources */,
 				BDC09EC028FD20AD0024507F /* Requestable.swift in Sources */,

--- a/GitHubSearchApp.xcodeproj/project.pbxproj
+++ b/GitHubSearchApp.xcodeproj/project.pbxproj
@@ -16,6 +16,8 @@
 		BD0A634028F7E2D500C080A5 /* SearchRepoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD0A633F28F7E2D500C080A5 /* SearchRepoViewController.swift */; };
 		BD0A634228F7E32700C080A5 /* FavoriteRepoViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD0A634128F7E32700C080A5 /* FavoriteRepoViewController.swift */; };
 		BD2E243B28FFD349003513B0 /* MockURLSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2E243A28FFD349003513B0 /* MockURLSession.swift */; };
+		BD2E243D28FFE7FE003513B0 /* SearchRepoViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2E243C28FFE7FE003513B0 /* SearchRepoViewModel.swift */; };
+		BD2E244229000FD9003513B0 /* Property.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2E244129000FD9003513B0 /* Property.swift */; };
 		BD33FB9528FEBB0D00F42776 /* APIEndpoints.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD33FB9428FEBB0D00F42776 /* APIEndpoints.swift */; };
 		BD33FB9728FEC5CE00F42776 /* MockData.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD33FB9628FEC5CE00F42776 /* MockData.swift */; };
 		BDBFB70128FD9BD90071FA1C /* SearchRepoRequestDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = BDBFB70028FD9BD90071FA1C /* SearchRepoRequestDTO.swift */; };
@@ -56,6 +58,8 @@
 		BD0A633F28F7E2D500C080A5 /* SearchRepoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchRepoViewController.swift; sourceTree = "<group>"; };
 		BD0A634128F7E32700C080A5 /* FavoriteRepoViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FavoriteRepoViewController.swift; sourceTree = "<group>"; };
 		BD2E243A28FFD349003513B0 /* MockURLSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockURLSession.swift; sourceTree = "<group>"; };
+		BD2E243C28FFE7FE003513B0 /* SearchRepoViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchRepoViewModel.swift; sourceTree = "<group>"; };
+		BD2E244129000FD9003513B0 /* Property.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Property.swift; sourceTree = "<group>"; };
 		BD33FB9428FEBB0D00F42776 /* APIEndpoints.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIEndpoints.swift; sourceTree = "<group>"; };
 		BD33FB9628FEC5CE00F42776 /* MockData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockData.swift; sourceTree = "<group>"; };
 		BDBFB70028FD9BD90071FA1C /* SearchRepoRequestDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchRepoRequestDTO.swift; sourceTree = "<group>"; };
@@ -128,6 +132,7 @@
 		BD0A632828F7DFE400C080A5 /* GitHubSearchApp */ = {
 			isa = PBXGroup;
 			children = (
+				BD2E243E29000F9D003513B0 /* Support */,
 				BDC09EFC28FD59AF0024507F /* Domain */,
 				BDC09EF728FD569D0024507F /* Data */,
 				BD0A634628F7EF4800C080A5 /* Application */,
@@ -152,6 +157,7 @@
 			isa = PBXGroup;
 			children = (
 				BD0A633F28F7E2D500C080A5 /* SearchRepoViewController.swift */,
+				BD2E243C28FFE7FE003513B0 /* SearchRepoViewModel.swift */,
 			);
 			path = SearchRepo;
 			sourceTree = "<group>";
@@ -171,6 +177,14 @@
 				BD0A632B28F7DFE400C080A5 /* SceneDelegate.swift */,
 			);
 			path = Application;
+			sourceTree = "<group>";
+		};
+		BD2E243E29000F9D003513B0 /* Support */ = {
+			isa = PBXGroup;
+			children = (
+				BD2E244129000FD9003513B0 /* Property.swift */,
+			);
+			path = Support;
 			sourceTree = "<group>";
 		};
 		BD33FB9228FEBABA00F42776 /* Common */ = {
@@ -485,10 +499,12 @@
 				BDC09EC628FD273B0024507F /* Provider.swift in Sources */,
 				BD0A632A28F7DFE400C080A5 /* AppDelegate.swift in Sources */,
 				BDC09EFF28FD59C60024507F /* Repository.swift in Sources */,
+				BD2E243D28FFE7FE003513B0 /* SearchRepoViewModel.swift in Sources */,
 				BDC09EBE28FCDA950024507F /* Endpoint.swift in Sources */,
 				BD0A634028F7E2D500C080A5 /* SearchRepoViewController.swift in Sources */,
 				BDC09EC828FD280C0024507F /* Responsable.swift in Sources */,
 				BDBFB70128FD9BD90071FA1C /* SearchRepoRequestDTO.swift in Sources */,
+				BD2E244229000FD9003513B0 /* Property.swift in Sources */,
 				BD0A632C28F7DFE400C080A5 /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/GitHubSearchApp/Domain/Entities/Repository.swift
+++ b/GitHubSearchApp/Domain/Entities/Repository.swift
@@ -6,7 +6,13 @@
 //
 
 import Foundation
+import Differentiator
 
-struct Repository {
+struct Repository: IdentifiableType, Equatable {
+    let id = UUID()
     let name: String
+    
+    var identity: UUID {
+        return id
+    }
 }

--- a/GitHubSearchApp/Infrastructure/Endpoint/Requestable.swift
+++ b/GitHubSearchApp/Infrastructure/Endpoint/Requestable.swift
@@ -15,10 +15,10 @@ protocol Requestable {
 
 extension Requestable {
     func makeURLRequest() throws -> URLRequest {
-        let urlString = baseURL + path
-        guard var urlComponent = URLComponents(string: urlString) else {
+        guard var urlComponent = URLComponents(string: baseURL) else {
             throw NetworkError.urlComponentError
         }
+        urlComponent.path = path
         
         guard let queryDictionary = try? queryParameter.toDictionary() else {
             throw NetworkError.queryEncodingError

--- a/GitHubSearchApp/Presentation/MySection.swift
+++ b/GitHubSearchApp/Presentation/MySection.swift
@@ -1,0 +1,27 @@
+//
+//  MySection.swift
+//  GitHubSearchApp
+//
+//  Created by chmini on 2022/10/21.
+//
+
+import Foundation
+import RxDataSources
+
+struct MySection {
+    var headerTitle: String
+    var items: [Item]
+}
+
+extension MySection: AnimatableSectionModelType {
+    typealias Item = Repository
+    
+    var identity: String {
+        return headerTitle
+    }
+    
+    init(original: Self, items: [Item]) {
+        self = original
+        self.items = items
+    }
+}

--- a/GitHubSearchApp/Presentation/SearchRepo/SearchRepoViewController.swift
+++ b/GitHubSearchApp/Presentation/SearchRepo/SearchRepoViewController.swift
@@ -59,11 +59,11 @@ final class SearchRepoViewController: UIViewController, UIScrollViewDelegate {
         let configureCell: (TableViewSectionedDataSource<MySection>,
                             UITableView,
                             IndexPath,
-                            TestModel) -> UITableViewCell
+                            Repository) -> UITableViewCell
         = { dataSource, tableView, indexPath, item in
             let cell = tableView.dequeueReusableCell(withIdentifier: "cell", for: indexPath)
             var content = cell.defaultContentConfiguration()
-            content.text = item.num
+            content.text = item.name
             cell.contentConfiguration = content
             cell.separatorInset = .zero
             
@@ -73,11 +73,6 @@ final class SearchRepoViewController: UIViewController, UIScrollViewDelegate {
     }
     
     private func bindToViewModel() {
-        let data = MySection(headerTitle: "test", items: (1...10).map{ TestModel(num: String($0)) })
-        Observable.just([data])
-            .bind(to: tableView.rx.items(dataSource: dataSource))
-            .disposed(by: disposeBag)
-        
         let searchBarText = searchBar.searchBar.rx.text.orEmpty
             .debounce(RxTimeInterval.milliseconds(1500), scheduler: MainScheduler.instance)
             .asDriver(onErrorJustReturn: "")
@@ -91,36 +86,8 @@ final class SearchRepoViewController: UIViewController, UIScrollViewDelegate {
             })
             .disposed(by: disposeBag)
         
-//        output.$repoList
-//            .bind(to: tableView.rx.items(dataSource: dataSource))
-//            .disposed(by: disposeBag)
-    }
-}
-
-struct TestModel {
-    let num: String
-}
-
-extension TestModel: IdentifiableType, Equatable {
-    var identity: String {
-        return num
-    }
-}
-
-struct MySection {
-    var headerTitle: String
-    var items: [Item]
-}
-
-extension MySection: AnimatableSectionModelType {
-    typealias Item = TestModel
-    
-    var identity: String {
-        return headerTitle
-    }
-    
-    init(original: Self, items: [Item]) {
-        self = original
-        self.items = items
+        output.$repoList
+            .bind(to: tableView.rx.items(dataSource: dataSource))
+            .disposed(by: disposeBag)
     }
 }

--- a/GitHubSearchApp/Presentation/SearchRepo/SearchRepoViewController.swift
+++ b/GitHubSearchApp/Presentation/SearchRepo/SearchRepoViewController.swift
@@ -8,6 +8,7 @@
 import UIKit
 import RxSwift
 import RxCocoa
+import RxDataSources
 
 final class SearchRepoViewController: UIViewController {
     let searchRepoViewModel = SearchRepoViewModel()

--- a/GitHubSearchApp/Presentation/SearchRepo/SearchRepoViewController.swift
+++ b/GitHubSearchApp/Presentation/SearchRepo/SearchRepoViewController.swift
@@ -6,9 +6,11 @@
 //
 
 import UIKit
+import RxSwift
+import RxCocoa
 
 final class SearchRepoViewController: UIViewController {
-    let numberList = (1...20).map { $0 }
+    let searchRepoViewModel = SearchRepoViewModel()
     
     private let searchBar: UISearchController = {
         let sb = UISearchController()
@@ -30,6 +32,7 @@ final class SearchRepoViewController: UIViewController {
         configureUI()
         setupSearchBar()
         setupTableView()
+        bindToViewModel()
     }
     
     private func configureUI() {
@@ -44,38 +47,51 @@ final class SearchRepoViewController: UIViewController {
         ])
     }
     
+    let disposeBag = DisposeBag()
+    
+    private func bindToViewModel() {
+        let input = SearchRepoViewModel.Input(searchBarText: searchBar.searchBar.rx.text.orEmpty.asDriver())
+        let output = searchRepoViewModel.transform(input, disposeBag: disposeBag)
+        
+        output.$searchBarText
+            .subscribe(onNext: { text in
+                print(text)
+            })
+            .disposed(by: disposeBag)
+    }
+    
     private func setupTableView() {
-        self.tableView.dataSource = self
+//        self.tableView.dataSource = self
     }
     
     private func setupSearchBar() {
         navigationItem.searchController = searchBar
-        searchBar.searchBar.delegate = self
+//        searchBar.searchBar.delegate = self
     }
 }
 
-extension SearchRepoViewController: UISearchBarDelegate {
-    func searchBarTextDidEndEditing(_ searchBar: UISearchBar) {
-        guard let text = searchBar.text else {
-            return
-        }
-        print(text)
-    }
-}
-
-extension SearchRepoViewController: UITableViewDataSource {
-    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return numberList.count
-    }
-    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        let cell = tableView.dequeueReusableCell(withIdentifier: "cell", for: indexPath)
-        var content = cell.defaultContentConfiguration()
-        content.text = "\(numberList[indexPath.row])"
-        cell.contentConfiguration = content
-        
-        cell.separatorInset = .zero
-        return cell
-    }
-}
+//extension SearchRepoViewController: UISearchBarDelegate {
+//    func searchBarTextDidEndEditing(_ searchBar: UISearchBar) {
+//        guard let text = searchBar.text else {
+//            return
+//        }
+//        print(text)
+//    }
+//}
+//
+//extension SearchRepoViewController: UITableViewDataSource {
+//    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+//        return numberList.count
+//    }
+//    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+//        let cell = tableView.dequeueReusableCell(withIdentifier: "cell", for: indexPath)
+//        var content = cell.defaultContentConfiguration()
+//        content.text = "\(numberList[indexPath.row])"
+//        cell.contentConfiguration = content
+//
+//        cell.separatorInset = .zero
+//        return cell
+//    }
+//}
 
 

--- a/GitHubSearchApp/Presentation/SearchRepo/SearchRepoViewController.swift
+++ b/GitHubSearchApp/Presentation/SearchRepo/SearchRepoViewController.swift
@@ -62,6 +62,12 @@ final class SearchRepoViewController: UIViewController {
                 print(text)
             })
             .disposed(by: disposeBag)
+        
+        output.$repoList
+            .subscribe(onNext: { repoList in
+                print(repoList.count)
+            })
+            .disposed(by: disposeBag)
     }
     
     private func setupTableView() {

--- a/GitHubSearchApp/Presentation/SearchRepo/SearchRepoViewController.swift
+++ b/GitHubSearchApp/Presentation/SearchRepo/SearchRepoViewController.swift
@@ -10,8 +10,10 @@ import RxSwift
 import RxCocoa
 import RxDataSources
 
-final class SearchRepoViewController: UIViewController {
+final class SearchRepoViewController: UIViewController, UIScrollViewDelegate {
     let searchRepoViewModel = SearchRepoViewModel()
+    let disposeBag = DisposeBag()
+    var dataSource: RxTableViewSectionedReloadDataSource<MySection>!
     
     private let searchBar: UISearchController = {
         let sb = UISearchController()
@@ -48,9 +50,34 @@ final class SearchRepoViewController: UIViewController {
         ])
     }
     
-    let disposeBag = DisposeBag()
+    private func setupSearchBar() {
+        navigationItem.searchController = searchBar
+    }
+    
+    private func setupTableView() {
+        self.tableView.rx.setDelegate(self).disposed(by: disposeBag)
+        let configureCell: (TableViewSectionedDataSource<MySection>,
+                            UITableView,
+                            IndexPath,
+                            TestModel) -> UITableViewCell
+        = { dataSource, tableView, indexPath, item in
+            let cell = tableView.dequeueReusableCell(withIdentifier: "cell", for: indexPath)
+            var content = cell.defaultContentConfiguration()
+            content.text = item.num
+            cell.contentConfiguration = content
+            cell.separatorInset = .zero
+            
+            return cell
+        }
+        self.dataSource = .init(configureCell: configureCell)
+    }
     
     private func bindToViewModel() {
+        let data = MySection(headerTitle: "test", items: (1...10).map{ TestModel(num: String($0)) })
+        Observable.just([data])
+            .bind(to: tableView.rx.items(dataSource: dataSource))
+            .disposed(by: disposeBag)
+        
         let searchBarText = searchBar.searchBar.rx.text.orEmpty
             .debounce(RxTimeInterval.milliseconds(1500), scheduler: MainScheduler.instance)
             .asDriver(onErrorJustReturn: "")
@@ -64,17 +91,36 @@ final class SearchRepoViewController: UIViewController {
             })
             .disposed(by: disposeBag)
         
-        output.$repoList
-            .subscribe(onNext: { repoList in
-                print(repoList.count)
-            })
-            .disposed(by: disposeBag)
+//        output.$repoList
+//            .bind(to: tableView.rx.items(dataSource: dataSource))
+//            .disposed(by: disposeBag)
+    }
+}
+
+struct TestModel {
+    let num: String
+}
+
+extension TestModel: IdentifiableType, Equatable {
+    var identity: String {
+        return num
+    }
+}
+
+struct MySection {
+    var headerTitle: String
+    var items: [Item]
+}
+
+extension MySection: AnimatableSectionModelType {
+    typealias Item = TestModel
+    
+    var identity: String {
+        return headerTitle
     }
     
-    private func setupTableView() {
-    }
-    
-    private func setupSearchBar() {
-        navigationItem.searchController = searchBar
+    init(original: Self, items: [Item]) {
+        self = original
+        self.items = items
     }
 }

--- a/GitHubSearchApp/Presentation/SearchRepo/SearchRepoViewController.swift
+++ b/GitHubSearchApp/Presentation/SearchRepo/SearchRepoViewController.swift
@@ -50,8 +50,12 @@ final class SearchRepoViewController: UIViewController {
     let disposeBag = DisposeBag()
     
     private func bindToViewModel() {
-        let input = SearchRepoViewModel.Input(searchBarText: searchBar.searchBar.rx.text.orEmpty.asDriver())
-        let output = searchRepoViewModel.transform(input, disposeBag: disposeBag)
+        let searchBarText = searchBar.searchBar.rx.text.orEmpty
+            .debounce(RxTimeInterval.milliseconds(1500), scheduler: MainScheduler.instance)
+            .asDriver(onErrorJustReturn: "")
+        
+        let input = SearchRepoViewModel.Input(searchBarText: searchBarText)
+        let output = searchRepoViewModel.transform(input: input, disposeBag: disposeBag)
         
         output.$searchBarText
             .subscribe(onNext: { text in
@@ -61,37 +65,9 @@ final class SearchRepoViewController: UIViewController {
     }
     
     private func setupTableView() {
-//        self.tableView.dataSource = self
     }
     
     private func setupSearchBar() {
         navigationItem.searchController = searchBar
-//        searchBar.searchBar.delegate = self
     }
 }
-
-//extension SearchRepoViewController: UISearchBarDelegate {
-//    func searchBarTextDidEndEditing(_ searchBar: UISearchBar) {
-//        guard let text = searchBar.text else {
-//            return
-//        }
-//        print(text)
-//    }
-//}
-//
-//extension SearchRepoViewController: UITableViewDataSource {
-//    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-//        return numberList.count
-//    }
-//    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-//        let cell = tableView.dequeueReusableCell(withIdentifier: "cell", for: indexPath)
-//        var content = cell.defaultContentConfiguration()
-//        content.text = "\(numberList[indexPath.row])"
-//        cell.contentConfiguration = content
-//
-//        cell.separatorInset = .zero
-//        return cell
-//    }
-//}
-
-

--- a/GitHubSearchApp/Presentation/SearchRepo/SearchRepoViewModel.swift
+++ b/GitHubSearchApp/Presentation/SearchRepo/SearchRepoViewModel.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import RxSwift
+import RxCocoa
 
 protocol ViewModel {
     associatedtype Input
@@ -17,14 +18,20 @@ protocol ViewModel {
 
 class SearchRepoViewModel: ViewModel {
     struct Input {
+        let searchBarText: Driver<String>
     }
     
     struct Output {
-        @Property var repoList = [Repository]()
+//        @Property var repoList = [Repository]()
+        @Property var searchBarText = ""
     }
     
     func transform(_ input: Input, disposeBag: DisposeBag) -> Output {
-        var output = Output()
+        let output = Output()
+        
+        input.searchBarText
+            .drive(output.$searchBarText)
+            .disposed(by: disposeBag)
         
         return output
     }

--- a/GitHubSearchApp/Presentation/SearchRepo/SearchRepoViewModel.swift
+++ b/GitHubSearchApp/Presentation/SearchRepo/SearchRepoViewModel.swift
@@ -15,5 +15,18 @@ protocol ViewModel {
     func transform(_ input: Input, disposeBag: DisposeBag) -> Output
 }
 
-class SearchRepoViewModel {
+class SearchRepoViewModel: ViewModel {
+    struct Input {
+    }
+    
+    struct Output {
+        @Property var repoList = [Repository]()
+    }
+    
+    func transform(_ input: Input, disposeBag: DisposeBag) -> Output {
+        var output = Output()
+        
+        return output
+    }
+    
 }

--- a/GitHubSearchApp/Presentation/SearchRepo/SearchRepoViewModel.swift
+++ b/GitHubSearchApp/Presentation/SearchRepo/SearchRepoViewModel.swift
@@ -1,0 +1,11 @@
+//
+//  SearchRepoViewModel.swift
+//  GitHubSearchApp
+//
+//  Created by chmini on 2022/10/19.
+//
+
+import Foundation
+
+class SearchRepoViewModel {
+}

--- a/GitHubSearchApp/Presentation/SearchRepo/SearchRepoViewModel.swift
+++ b/GitHubSearchApp/Presentation/SearchRepo/SearchRepoViewModel.swift
@@ -19,13 +19,15 @@ protocol ViewModel {
 class SearchRepoViewModel {
     let provider = ProviderImpl(session: URLSession.shared)
     
-    func getRepoList(with text: String) -> Single<[Repository]> {
+    func getRepoList(with text: String) -> Single<[MySection]> {
         let searchRepoRequestDTO = SearchRepoRequestDTO(q: text)
         let endpoint = APIEndpoints.searchRepo(with: searchRepoRequestDTO)
+        var mySection = MySection(headerTitle: "mySection", items: [])
         
         return provider.request(endpoint: endpoint)
-            .map { data in
-                data.toDomain()
+            .map { data -> [MySection] in
+                mySection.items = data.toDomain()
+                return [mySection]
             }
     }
 }
@@ -36,7 +38,7 @@ extension SearchRepoViewModel: ViewModel {
     }
     
     struct Output {
-        @Property var repoList = [Repository]()
+        @Property var repoList = [MySection]()
         @Property var searchBarText = ""
     }
     
@@ -59,5 +61,4 @@ extension SearchRepoViewModel: ViewModel {
         
         return output
     }
-    
 }

--- a/GitHubSearchApp/Presentation/SearchRepo/SearchRepoViewModel.swift
+++ b/GitHubSearchApp/Presentation/SearchRepo/SearchRepoViewModel.swift
@@ -13,25 +13,59 @@ protocol ViewModel {
     associatedtype Input
     associatedtype Output
     
-    func transform(_ input: Input, disposeBag: DisposeBag) -> Output
+    func transform(input: Input, disposeBag: DisposeBag) -> Output
 }
 
-class SearchRepoViewModel: ViewModel {
+class SearchRepoViewModel {
+    let provider = ProviderImpl(session: URLSession.shared)
+    
+    func getRepo(with text: String) -> Single<[Repository]> {
+        let searchRepoRequestDTO = SearchRepoRequestDTO(q: text)
+        let endpoint = APIEndpoints.searchRepo(with: searchRepoRequestDTO)
+        
+        return provider.request(endpoint: endpoint)
+            .map { data in
+                data.toDomain()
+            }
+    }
+}
+
+extension SearchRepoViewModel: ViewModel {
     struct Input {
         let searchBarText: Driver<String>
     }
     
     struct Output {
-//        @Property var repoList = [Repository]()
+        @Property var repoList = [Repository]()
         @Property var searchBarText = ""
     }
     
-    func transform(_ input: Input, disposeBag: DisposeBag) -> Output {
+    func transform(input: Input, disposeBag: DisposeBag) -> Output {
         let output = Output()
         
         input.searchBarText
             .drive(output.$searchBarText)
             .disposed(by: disposeBag)
+        
+        input.searchBarText
+            .asObservable()
+            .filter { $0 != "" }
+            .withUnretained(self)
+            .flatMapLatest { owner, text in
+                owner.getRepo(with: text)
+            }
+            .subscribe(onNext: {data in
+                print(data.first?.name)
+            }, onError: { error in
+                if let error = error as? NetworkError {
+                    print(error.description)
+                } else {
+                    print(error.localizedDescription)
+                }
+            })
+            .disposed(by: disposeBag)
+//            .bind(to: output.$repoList)
+//            .disposed(by: disposeBag)
         
         return output
     }

--- a/GitHubSearchApp/Presentation/SearchRepo/SearchRepoViewModel.swift
+++ b/GitHubSearchApp/Presentation/SearchRepo/SearchRepoViewModel.swift
@@ -6,6 +6,14 @@
 //
 
 import Foundation
+import RxSwift
+
+protocol ViewModel {
+    associatedtype Input
+    associatedtype Output
+    
+    func transform(_ input: Input, disposeBag: DisposeBag) -> Output
+}
 
 class SearchRepoViewModel {
 }

--- a/GitHubSearchApp/Presentation/SearchRepo/SearchRepoViewModel.swift
+++ b/GitHubSearchApp/Presentation/SearchRepo/SearchRepoViewModel.swift
@@ -19,7 +19,7 @@ protocol ViewModel {
 class SearchRepoViewModel {
     let provider = ProviderImpl(session: URLSession.shared)
     
-    func getRepo(with text: String) -> Single<[Repository]> {
+    func getRepoList(with text: String) -> Single<[Repository]> {
         let searchRepoRequestDTO = SearchRepoRequestDTO(q: text)
         let endpoint = APIEndpoints.searchRepo(with: searchRepoRequestDTO)
         
@@ -52,20 +52,10 @@ extension SearchRepoViewModel: ViewModel {
             .filter { $0 != "" }
             .withUnretained(self)
             .flatMapLatest { owner, text in
-                owner.getRepo(with: text)
+                owner.getRepoList(with: text)
             }
-            .subscribe(onNext: {data in
-                print(data.first?.name)
-            }, onError: { error in
-                if let error = error as? NetworkError {
-                    print(error.description)
-                } else {
-                    print(error.localizedDescription)
-                }
-            })
+            .bind(to: output.$repoList)
             .disposed(by: disposeBag)
-//            .bind(to: output.$repoList)
-//            .disposed(by: disposeBag)
         
         return output
     }

--- a/GitHubSearchApp/Support/Property.swift
+++ b/GitHubSearchApp/Support/Property.swift
@@ -1,0 +1,40 @@
+//
+//  Property.swift
+//  GitHubSearchApp
+//
+//  Created by chmini on 2022/10/19.
+//
+
+import Foundation
+import RxCocoa
+
+@propertyWrapper
+struct Property<Value> {
+    let lock = NSLock()
+    var relay: BehaviorRelay<Value>
+    
+    init(_ value: Value) {
+        self.relay = BehaviorRelay<Value>(value: value)
+    }
+    
+    var wrappedValue: Value {
+        get { load() }
+        set { store(newValue) }
+    }
+    
+    var projectedValue: BehaviorRelay<Value> {
+        return self.relay
+    }
+    
+    func load() -> Value {
+        lock.lock()
+        defer { lock.unlock() }
+        return self.relay.value
+    }
+    
+    func store(_ value: Value) {
+        lock.lock()
+        defer { lock.unlock() }
+        self.relay.accept(value)
+    }
+}

--- a/GitHubSearchApp/Support/Property.swift
+++ b/GitHubSearchApp/Support/Property.swift
@@ -12,26 +12,26 @@ import RxCocoa
 struct Property<Value> {
     let lock = NSLock()
     var relay: BehaviorRelay<Value>
-    
-    init(_ value: Value) {
-        self.relay = BehaviorRelay<Value>(value: value)
+
+    init(wrappedValue: Value) {
+        self.relay = BehaviorRelay<Value>(value: wrappedValue)
     }
     
     var wrappedValue: Value {
         get { load() }
         set { store(newValue) }
     }
-    
+
     var projectedValue: BehaviorRelay<Value> {
         return self.relay
     }
-    
+
     func load() -> Value {
         lock.lock()
         defer { lock.unlock() }
         return self.relay.value
     }
-    
+
     func store(_ value: Value) {
         lock.lock()
         defer { lock.unlock() }

--- a/Podfile
+++ b/Podfile
@@ -9,6 +9,7 @@ target 'GitHubSearchApp' do
 
   pod 'RxSwift', '6.5.0'
   pod 'RxCocoa', '6.5.0'
+  pod 'RxDataSources'
 
 end
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,9 +1,14 @@
 PODS:
+  - Differentiator (5.0.0)
   - RxBlocking (6.5.0):
     - RxSwift (= 6.5.0)
   - RxCocoa (6.5.0):
     - RxRelay (= 6.5.0)
     - RxSwift (= 6.5.0)
+  - RxDataSources (5.0.0):
+    - Differentiator (~> 5.0)
+    - RxCocoa (~> 6.0)
+    - RxSwift (~> 6.0)
   - RxRelay (6.5.0):
     - RxSwift (= 6.5.0)
   - RxSwift (6.5.0)
@@ -11,21 +16,26 @@ PODS:
 DEPENDENCIES:
   - RxBlocking (= 6.5.0)
   - RxCocoa (= 6.5.0)
+  - RxDataSources
   - RxSwift (= 6.5.0)
 
 SPEC REPOS:
   trunk:
+    - Differentiator
     - RxBlocking
     - RxCocoa
+    - RxDataSources
     - RxRelay
     - RxSwift
 
 SPEC CHECKSUMS:
+  Differentiator: e8497ceab83c1b10ca233716d547b9af21b9344d
   RxBlocking: 04b5fd28bb5ea49f7d64b80db8bbfe50d9cc1c7d
   RxCocoa: 94f817b71c07517321eb4f9ad299112ca8af743b
+  RxDataSources: aa47cc1ed6c500fa0dfecac5c979b723542d79cf
   RxRelay: 1de1523e604c72b6c68feadedd1af3b1b4d0ecbd
   RxSwift: 5710a9e6b17f3c3d6e40d6e559b9fa1e813b2ef8
 
-PODFILE CHECKSUM: 2b75d760d4fd25e184373acee8f4bfecf6f0ec76
+PODFILE CHECKSUM: 3f4bd4883cb815a9f1dfbd033f090961e8e81500
 
 COCOAPODS: 1.11.2


### PR DESCRIPTION
## 🛠 변경사항 및 구현한 기능
- #12
- protocol ViewModel
- @propertyWrapper Property
- rxdatasource

## 🤔 고민한 점
``` swift
class TestViewModel: ViewModel {
    struct Output {
        let fetchedData: BehaviorRelay<[Repository]>
    }
    
    func transform(input: Input, disposeBag: DisposeBag) -> Output {
        let fetchedData = BehaviorRelay<[Repository]>(value: [])
        let output = Output(fetchedData: fetchedData)
        
        return output
    }
}
```
ViewModel의 `Output`을 생성할때 보통 fetchedData처럼 변수를 따로 지정한 다음 output에 넣어주곤 했는데
SwiftUI의 `@State`를 사용할수는 없을까 생각...🤔

## 🙌 해결한 방법

``` swift
@propertyWrapper
struct Property<Value> {
    let lock = NSLock()
    var relay: BehaviorRelay<Value>

    init(wrappedValue: Value) {
        self.relay = BehaviorRelay<Value>(value: wrappedValue)
    }
    
    var wrappedValue: Value {
        get { load() }
        set { store(newValue) }
    }

    var projectedValue: BehaviorRelay<Value> {
        return self.relay
    }

    func load() -> Value {
        lock.lock()
        defer { lock.unlock() }
        return self.relay.value
    }

    func store(_ value: Value) {
        lock.lock()
        defer { lock.unlock() }
        self.relay.accept(value)
    }
}
// 뷰컨에서 사용할때 '$'를 붙여주면 됨
output.$repoList
            .bind(to: tableView.rx.items(dataSource: dataSource))
            .disposed(by: disposeBag)
```
`@propertyWrapper`사용하여 직접 구현, [참고](https://eunjin3786.tistory.com/472)

## ✅ PR 포인트
- 테이블뷰 Reload할때 `RxDataSource`를 사용하기로 했는데 이를 위해선 Section Model을 사용해야됨
-> protocol `AnimatableSectionModelType`을 채택한 `MySection` 모델 구현
- 위의 struct `Property`