### PR TITLE
Feature/#20 - Pagination 기능 추가

### DIFF
--- a/GitHubSearchApp/Data/Gateways/DefaultRepoGateway.swift
+++ b/GitHubSearchApp/Data/Gateways/DefaultRepoGateway.swift
@@ -9,11 +9,11 @@ import Foundation
 import RxSwift
 
 protocol RepoGateWay {
-    func fetchRepoList(with searchRepoRequestDTO: SearchRepoRequestDTO) -> Single<SearchRepoResponseDTO>
+    func fetchRepoList(with searchRepoRequestDTO: SearchRepoRequestDTO) -> Observable<Result<SearchRepoResponseDTO, Error>>
 }
 
 struct DefaultRepoGateway: RepoGateWay {
-    func fetchRepoList(with searchRepoRequestDTO: SearchRepoRequestDTO) -> Single<SearchRepoResponseDTO> {
+    func fetchRepoList(with searchRepoRequestDTO: SearchRepoRequestDTO) -> Observable<Result<SearchRepoResponseDTO, Error>> {
         let endpoint = APIEndpoints.searchRepo(with: searchRepoRequestDTO)
         return ProviderImpl.shared.request(endpoint: endpoint)
     }

--- a/GitHubSearchApp/Data/Network/DataMapping/SearchRepoRequestDTO.swift
+++ b/GitHubSearchApp/Data/Network/DataMapping/SearchRepoRequestDTO.swift
@@ -8,12 +8,12 @@
 import Foundation
 
 struct SearchRepoRequestDTO: Encodable {
-    let searchString: String
-    let perPage: Int
+    let searchText: String
+    let perPage: Int = 20
     let currentPage: Int
     
     enum CodingKeys: String, CodingKey {
-        case searchString = "q"
+        case searchText = "q"
         case perPage = "per_page"
         case currentPage = "page"
     }

--- a/GitHubSearchApp/Data/Network/DataMapping/SearchRepoRequestDTO.swift
+++ b/GitHubSearchApp/Data/Network/DataMapping/SearchRepoRequestDTO.swift
@@ -8,5 +8,13 @@
 import Foundation
 
 struct SearchRepoRequestDTO: Encodable {
-    let q: String
+    let searchString: String
+    let perPage: Int
+    let currentPage: Int
+    
+    enum CodingKeys: String, CodingKey {
+        case searchString = "q"
+        case perPage = "per_page"
+        case currentPage = "page"
+    }
 }

--- a/GitHubSearchApp/Data/Network/DataMapping/SearchRepoResponseDTO.swift
+++ b/GitHubSearchApp/Data/Network/DataMapping/SearchRepoResponseDTO.swift
@@ -15,6 +15,12 @@ struct SearchRepoResponseDTO: Decodable {
         case totalCount = "total_count"
         case repositoryDTOList = "items"
     }
+    
+    init(from decoder: Decoder) throws {
+        let value = try decoder.container(keyedBy: CodingKeys.self)
+        totalCount = (try? value.decode(Int.self, forKey: .totalCount)) ?? 0
+        repositoryDTOList = (try? value.decode([RepositoryDTO].self, forKey: .repositoryDTOList)) ?? []
+    }
 }
 
 extension SearchRepoResponseDTO {
@@ -43,5 +49,13 @@ struct RepositoryDTO: Decodable {
         case description
         case starCount = "stargazers_count"
         case urlString = "html_url"
+    }
+    
+    init(from decoder: Decoder) throws {
+        let value = try decoder.container(keyedBy: CodingKeys.self)
+        name = (try? value.decode(String.self, forKey: .name)) ?? ""
+        description = (try? value.decode(String.self, forKey: .description)) ?? ""
+        starCount = (try? value.decode(Int.self, forKey: .starCount)) ?? 0
+        urlString = (try? value.decode(String.self, forKey: .urlString)) ?? ""
     }
 }

--- a/GitHubSearchApp/Domain/UseCases/DefaultRepoUseCase.swift
+++ b/GitHubSearchApp/Domain/UseCases/DefaultRepoUseCase.swift
@@ -9,32 +9,22 @@ import Foundation
 import RxSwift
 
 protocol RepoUseCase {
-    func getRepoList(searchText: String) -> Observable<[MySection]>
+    func getRepoList(searchText: String, currentPage: Int) -> Observable<[MySection]>
 }
 
 class DefaultRepoUseCase: RepoUseCase {
     let repoGateWay: RepoGateWay
-    let searchRepoSubject = PublishSubject<String>()
     var mySection = MySection(headerTitle: "mySection", items: [])
     
     init (repoGateWay: RepoGateWay) {
         self.repoGateWay = repoGateWay
     }
     
-    func getRepoList(searchText: String) -> Observable<[MySection]> {
-        searchRepoSubject.onNext(searchText)
-        
-        return searchRepoSubject
-            .filter { $0 != "" }
-            .withUnretained(self)
-            .flatMap { (owner, text) in
-                return owner.repoGateWay
-                    .fetchRepoList(with:
-                                    SearchRepoRequestDTO(searchString: text,
-                                                         perPage: 20,
-                                                         currentPage: 1)
-                    )
-            }
+    func getRepoList(searchText: String, currentPage: Int) -> Observable<[MySection]> {
+        return repoGateWay
+            .fetchRepoList(with: SearchRepoRequestDTO(searchText: searchText,
+                                                      currentPage: currentPage))
+            .asObservable()
             .withUnretained(self)
             .map { (owner, data) -> [MySection] in
                 owner.mySection.items = data.toDomain()

--- a/GitHubSearchApp/Domain/UseCases/DefaultRepoUseCase.swift
+++ b/GitHubSearchApp/Domain/UseCases/DefaultRepoUseCase.swift
@@ -29,7 +29,11 @@ class DefaultRepoUseCase: RepoUseCase {
             .withUnretained(self)
             .flatMap { (owner, text) in
                 return owner.repoGateWay
-                    .fetchRepoList(with: SearchRepoRequestDTO(q: text))
+                    .fetchRepoList(with:
+                                    SearchRepoRequestDTO(searchString: text,
+                                                         perPage: 20,
+                                                         currentPage: 1)
+                    )
             }
             .withUnretained(self)
             .map { (owner, data) -> [MySection] in

--- a/GitHubSearchApp/Domain/UseCases/DefaultRepoUseCase.swift
+++ b/GitHubSearchApp/Domain/UseCases/DefaultRepoUseCase.swift
@@ -9,7 +9,8 @@ import Foundation
 import RxSwift
 
 protocol RepoUseCase {
-    func getRepoList(searchText: String, currentPage: Int) -> Observable<[MySection]>
+    func getRepoList(searchText: String) -> Observable<[MySection]>
+    func getRepoList(searchText: String, currentPage: Int, originData: [Repository]) -> Observable<[MySection]>
 }
 
 class DefaultRepoUseCase: RepoUseCase {
@@ -20,14 +21,28 @@ class DefaultRepoUseCase: RepoUseCase {
         self.repoGateWay = repoGateWay
     }
     
-    func getRepoList(searchText: String, currentPage: Int) -> Observable<[MySection]> {
+    func getRepoList(searchText: String) -> Observable<[MySection]> {
+        return repoGateWay
+            .fetchRepoList(with: SearchRepoRequestDTO(searchText: searchText,
+                                                      currentPage: 1))
+            .asObservable()
+            .withUnretained(self)
+            .map { (owner, data) -> [MySection] in
+                owner.mySection.items = data.toDomain()
+                return [owner.mySection]
+            }
+    }
+    
+    func getRepoList(searchText: String,
+                     currentPage: Int,
+                     originData: [Repository]) -> Observable<[MySection]> {
         return repoGateWay
             .fetchRepoList(with: SearchRepoRequestDTO(searchText: searchText,
                                                       currentPage: currentPage))
             .asObservable()
             .withUnretained(self)
             .map { (owner, data) -> [MySection] in
-                owner.mySection.items = data.toDomain()
+                owner.mySection.items = originData + data.toDomain()
                 return [owner.mySection]
             }
     }

--- a/GitHubSearchApp/Infrastructure/Common/NetworkError.swift
+++ b/GitHubSearchApp/Infrastructure/Common/NetworkError.swift
@@ -7,7 +7,11 @@
 
 import Foundation
 
-enum NetworkError: Error {
+enum NetworkError: Error, Equatable {
+    static func == (lhs: NetworkError, rhs: NetworkError) -> Bool {
+        return lhs.description == rhs.description
+    }
+    
     case urlComponentError
     case queryEncodingError
     case makeURLError
@@ -16,6 +20,7 @@ enum NetworkError: Error {
     case statusCodeError(Int)
     case noDataError
     case decodingError
+    case requestLimitError
     
     var description: String {
         let base = "😡😡😡😡😡"
@@ -36,6 +41,8 @@ enum NetworkError: Error {
             return base + "noDataError"
         case .decodingError:
             return base + "decodingError"
+        case .requestLimitError:
+            return base + "requestLimitError"
         }
     }
 }

--- a/GitHubSearchApp/Infrastructure/Provider/Provider.swift
+++ b/GitHubSearchApp/Infrastructure/Provider/Provider.swift
@@ -65,6 +65,9 @@ class ProviderImpl: Provider {
         }
 
         if response.statusCode != 200 {
+            if response.statusCode == 403 {
+                completion(.failure(NetworkError.requestLimitError))
+            }
             completion(.failure(NetworkError.statusCodeError(response.statusCode)))
             return
         }

--- a/GitHubSearchApp/Presentation/SearchRepo/SearchRepoViewController.swift
+++ b/GitHubSearchApp/Presentation/SearchRepo/SearchRepoViewController.swift
@@ -129,6 +129,7 @@ extension SearchRepoViewController {
         let remainFromBottom = totalHeight - currentYOffset
         
         if remainFromBottom < frameHeight * 2 && viewModel.viewState == .idle {
+            print(111)
             viewModel.pagination.onNext(())
         }
     }

--- a/GitHubSearchApp/Presentation/SearchRepo/SearchRepoViewController.swift
+++ b/GitHubSearchApp/Presentation/SearchRepo/SearchRepoViewController.swift
@@ -120,3 +120,16 @@ extension SearchRepoViewController: UITableViewDelegate {
 }
 
 extension SearchRepoViewController: UIViewControllerTransitioningDelegate {}
+
+extension SearchRepoViewController {
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        let totalHeight = scrollView.contentSize.height
+        let frameHeight = scrollView.frame.size.height
+        let currentYOffset = scrollView.contentOffset.y
+        let remainFromBottom = totalHeight - currentYOffset
+        
+        if remainFromBottom < frameHeight * 2 {
+            
+        }
+    }
+}

--- a/GitHubSearchApp/Presentation/SearchRepo/SearchRepoViewController.swift
+++ b/GitHubSearchApp/Presentation/SearchRepo/SearchRepoViewController.swift
@@ -99,6 +99,12 @@ final class SearchRepoViewController: UIViewController, UIScrollViewDelegate {
         output.$repoList
             .bind(to: tableView.rx.items(dataSource: dataSource))
             .disposed(by: disposeBag)
+        
+        viewModel.alertRequestLimit
+            .subscribe(with: self, onNext: { (owner, _) in
+                owner.showRequestLimitAlert()
+            })
+            .disposed(by: disposeBag)
     }
     
     private func openInSafari(_ urlString: String) {
@@ -110,6 +116,15 @@ final class SearchRepoViewController: UIViewController, UIScrollViewDelegate {
         safariVC.modalPresentationStyle = .pageSheet
         
         present(safariVC, animated: true)
+    }
+    
+    private func showRequestLimitAlert() {
+        let alertController = UIAlertController(title: "API Request Limit", message: "10 per miniute, try after 1 minute", preferredStyle: .alert)
+        let action = UIAlertAction(title: "확인", style: .default)
+        alertController.addAction(action)
+        DispatchQueue.main.async {
+            self.present(alertController, animated: true)
+        }
     }
 }
 

--- a/GitHubSearchApp/Presentation/SearchRepo/SearchRepoViewController.swift
+++ b/GitHubSearchApp/Presentation/SearchRepo/SearchRepoViewController.swift
@@ -144,7 +144,6 @@ extension SearchRepoViewController {
         let remainFromBottom = totalHeight - currentYOffset
         
         if remainFromBottom < frameHeight * 2 && viewModel.viewState == .idle {
-            print(111)
             viewModel.pagination.onNext(())
         }
     }

--- a/GitHubSearchApp/Presentation/SearchRepo/SearchRepoViewController.swift
+++ b/GitHubSearchApp/Presentation/SearchRepo/SearchRepoViewController.swift
@@ -128,8 +128,8 @@ extension SearchRepoViewController {
         let currentYOffset = scrollView.contentOffset.y
         let remainFromBottom = totalHeight - currentYOffset
         
-        if remainFromBottom < frameHeight * 2 {
-//            viewModel.pagination.onNext(())
+        if remainFromBottom < frameHeight * 2 && viewModel.viewState == .idle {
+            viewModel.pagination.onNext(())
         }
     }
 }

--- a/GitHubSearchApp/Presentation/SearchRepo/SearchRepoViewController.swift
+++ b/GitHubSearchApp/Presentation/SearchRepo/SearchRepoViewController.swift
@@ -129,7 +129,7 @@ extension SearchRepoViewController {
         let remainFromBottom = totalHeight - currentYOffset
         
         if remainFromBottom < frameHeight * 2 {
-            
+//            viewModel.pagination.onNext(())
         }
     }
 }

--- a/GitHubSearchApp/Presentation/SearchRepo/SearchRepoViewModel.swift
+++ b/GitHubSearchApp/Presentation/SearchRepo/SearchRepoViewModel.swift
@@ -25,6 +25,7 @@ class SearchRepoViewModel {
             switch viewState {
             case .requestLimit:
                 print(viewState)
+                alertRequestLimit.onNext(())
                 DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(10)) { [weak self] in
                     guard let `self` = self else {
                         return
@@ -38,6 +39,7 @@ class SearchRepoViewModel {
     }
     
     let pagination = PublishSubject<Void>()
+    let alertRequestLimit = PublishSubject<Void>()
     
     init() {
         let repoGateWay = DefaultRepoGateway()

--- a/GitHubSearchApp/Presentation/SearchRepo/SearchRepoViewModel.swift
+++ b/GitHubSearchApp/Presentation/SearchRepo/SearchRepoViewModel.swift
@@ -20,7 +20,22 @@ class SearchRepoViewModel {
     
     var searchText: String = ""
     var currentPage: Int = 1
-    var viewState: ViewState = .idle
+    var viewState: ViewState = .idle {
+        didSet {
+            switch viewState {
+            case .requestLimit:
+                print(viewState)
+                DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(10)) { [weak self] in
+                    guard let `self` = self else {
+                        return
+                    }
+                    `self`.viewState = .idle
+                }
+            default:
+                print(viewState)
+            }
+        }
+    }
     
     let pagination = PublishSubject<Void>()
     
@@ -59,11 +74,18 @@ extension SearchRepoViewModel: ViewModelType {
         
         searchTextWithDebounce
             .withUnretained(self)
-            .flatMap { (owner, text) -> Observable<[MySection]> in
+            .flatMap { (owner, text) -> Observable<Result<[MySection], Error>> in
                 owner.setFirstFetching(with: text)
-                return owner.repoUseCase.getRepoList(searchText: text)
+                return owner.repoUseCase.getRepoList(searchText: text, currentPage: 1, originData: nil)
             }
             .withUnretained(self)
+            .map { (owner, result) -> [MySection] in
+                return owner.checkResult(result)
+            }
+            .withUnretained(self)
+            .filter { (owner, _) -> Bool in
+                return owner.viewState == .isLoading
+            }
             .map { (owner, mySection) -> [MySection] in
                 owner.viewState = .idle
                 return mySection
@@ -80,30 +102,18 @@ extension SearchRepoViewModel: ViewModelType {
             .filter { (owner, repoList) -> Bool in
                 owner.checkPagination(with: repoList)
             }
-            .flatMap { (owner, originData) -> Observable<[MySection]> in
+            .flatMap { (owner, originData) -> Observable<Result<[MySection], Error>> in
                 owner.setPaginationFetching()
                 return owner.repoUseCase.getRepoList(searchText: owner.searchText,
                                                      currentPage: owner.currentPage,
                                                      originData: originData!)
             }
-            .materialize()
             .withUnretained(self)
-            .map { owner, event -> Event<[MySection]> in
-                switch event {
-                case .error(let error):
-                    if let error = error as? NetworkError,
-                       error == .requestLimitError {
-                        owner.viewState = .requestLimit
-                    }
-                    return .next([])
-                default:
-                    return event
-                }
+            .map { (owner, result) -> [MySection] in
+                return owner.checkResult(result)
             }
-            .dematerialize()
             .withUnretained(self)
             .filter { (owner, _) -> Bool in
-                print(owner.viewState)
                 return owner.viewState == .isLoading
             }
             .map { (owner, mySection) -> [MySection] in
@@ -146,6 +156,27 @@ extension SearchRepoViewModel {
     func finishFetching() {
         if viewState != .requestLimit {
             viewState = .idle
+        }
+    }
+    
+    func checkResult(_ result: Result<[MySection], Error>) -> [MySection] {
+        switch result {
+        case .success(let mySection):
+            return mySection
+        case .failure(let error):
+            guard let error = error as? NetworkError else {
+                print(error.localizedDescription)
+                return []
+            }
+            
+            if error == .requestLimitError {
+                viewState = .requestLimit
+                currentPage -= 1
+                return []
+            }
+            
+            print(error.description)
+            return []
         }
     }
 }

--- a/GitHubSearchApp/Presentation/SearchRepo/SearchRepoViewModel.swift
+++ b/GitHubSearchApp/Presentation/SearchRepo/SearchRepoViewModel.swift
@@ -81,7 +81,6 @@ extension SearchRepoViewModel: ViewModelType {
             }
             .flatMap { (owner, originData) -> Observable<[MySection]> in
                 owner.setPaginationFetching()
-                
                 return owner.repoUseCase.getRepoList(searchText: owner.searchText,
                                                      currentPage: owner.currentPage,
                                                      originData: originData!)

--- a/GitHubSearchApp/Presentation/SearchRepo/SearchRepoViewModel.swift
+++ b/GitHubSearchApp/Presentation/SearchRepo/SearchRepoViewModel.swift
@@ -9,10 +9,19 @@ import Foundation
 import RxSwift
 import RxCocoa
 
+enum ViewState {
+    case idle
+    case isLoading
+}
+
 class SearchRepoViewModel {
     let repoUseCase: RepoUseCase
+    
     var searchText: String = ""
     var currentPage: Int = 1
+    var viewState: ViewState = .idle
+    
+    let pagination = PublishSubject<Void>()
     
     init() {
         let repoGateWay = DefaultRepoGateway()
@@ -20,7 +29,7 @@ class SearchRepoViewModel {
     }
 }
 
-extension SearchRepoViewModel: ViewModel {
+extension SearchRepoViewModel: ViewModelType {
     struct Input {
         let searchBarText: Observable<String>
     }
@@ -30,8 +39,9 @@ extension SearchRepoViewModel: ViewModel {
         @Property var searchBarText = ""
     }
     
-    func transform(input: Input, disposeBag: DisposeBag) -> Output {
+    func transform(input: Input, disposeBag: DisposeBag) -> Output  {
         let output = Output()
+        
         let searchTextWithDebounce = input.searchBarText
             .debounce(RxTimeInterval.milliseconds(1500), scheduler: MainScheduler.instance)
             .filter { [weak self] text in
@@ -40,6 +50,7 @@ extension SearchRepoViewModel: ViewModel {
                 }
                 return (text != "" && text != `self`.searchText)
             }
+            .share()
         
         searchTextWithDebounce
             .bind(to: output.$searchBarText)
@@ -48,13 +59,68 @@ extension SearchRepoViewModel: ViewModel {
         searchTextWithDebounce
             .withUnretained(self)
             .flatMap { (owner, text) -> Observable<[MySection]> in
-                owner.currentPage = 1
-                owner.searchText = text
-                return owner.repoUseCase.getRepoList(searchText: text, currentPage: 1)
+                owner.setFirstFetching(with: text)
+                return owner.repoUseCase.getRepoList(searchText: text)
+            }
+            .withUnretained(self)
+            .map { (owner, mySection) -> [MySection] in
+                owner.viewState = .idle
+                return mySection
+            }
+            .bind(to: output.$repoList)
+            .disposed(by: disposeBag)
+        
+        pagination
+            .map { _ -> [Repository]? in
+                let originData = output.repoList.first?.items as? Array<Repository>
+                return originData
+            }
+            .withUnretained(self)
+            .filter { (owner, repoList) -> Bool in
+                owner.checkPagination(with: repoList)
+            }
+            .flatMap { (owner, originData) -> Observable<[MySection]> in
+                owner.setPaginationFetching()
+                
+                return owner.repoUseCase.getRepoList(searchText: owner.searchText,
+                                                     currentPage: owner.currentPage,
+                                                     originData: originData!)
+            }
+            .withUnretained(self)
+            .map { (owner, mySection) -> [MySection] in
+                owner.viewState = .idle
+                return mySection
             }
             .bind(to: output.$repoList)
             .disposed(by: disposeBag)
         
         return output
+    }
+}
+
+extension SearchRepoViewModel {
+    func setFirstFetching(with text: String) {
+        viewState = .isLoading
+        currentPage = 1
+        searchText = text
+    }
+    
+    func setPaginationFetching() {
+        viewState = .isLoading
+        currentPage += 1
+    }
+    
+    func checkPagination(with originData: [Repository]?) -> Bool {
+        if searchText == "" || viewState == .isLoading {
+            return false
+        }
+        
+        if let originData = originData {
+            if !originData.isEmpty {
+                return true
+            }
+        }
+        
+        return false
     }
 }

--- a/GitHubSearchApp/Presentation/SearchRepo/SearchRepoViewModel.swift
+++ b/GitHubSearchApp/Presentation/SearchRepo/SearchRepoViewModel.swift
@@ -24,7 +24,6 @@ class SearchRepoViewModel {
         didSet {
             switch viewState {
             case .requestLimit:
-                print(viewState)
                 alertRequestLimit.onNext(())
                 DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(10)) { [weak self] in
                     guard let `self` = self else {
@@ -33,7 +32,7 @@ class SearchRepoViewModel {
                     `self`.viewState = .idle
                 }
             default:
-                print(viewState)
+                break
             }
         }
     }

--- a/GitHubSearchApp/Presentation/ViewModelType.swift
+++ b/GitHubSearchApp/Presentation/ViewModelType.swift
@@ -8,7 +8,7 @@
 import Foundation
 import RxSwift
 
-protocol ViewModel {
+protocol ViewModelType {
     associatedtype Input
     associatedtype Output
     


### PR DESCRIPTION
## 🛠 변경사항 및 구현한 기능
- #20 

## 🤔 고민한 점
- GitHub Search API가 1분당 10개로 제한되어있음
- Page가 1분안에 10개가 넘어가면 그 이후의 api 호출은 에러를 반환함
- RxSwift에서의(특히 네트워크 통신 부분) Error Handling
- 10개의 적은 Request Limit을 어떻게 처리할것인가

## 🙌 해결한 방법
1. RxSwift에서의(특히 네트워크 통신 부분) Error Handling
``` swift
protocol Provider {
//    기존코드 Single로 반환
//    func request<E: RequestResponsable, R: Decodable>(endpoint: E) -> Single<R> where E.Response == R

//    Result로 Response와 Error를 모두 반환
    func request<E: RequestResponsable, R: Decodable>(endpoint: E) -> Observable<Result<R, Error>> where E.Response == R
}
```
기존코드는 Single로 값을 하나만 반환해서 만약 .failure, error를 반환하면   
Pagination전체 스트림이 Dispose 되어버려 다음 pagination이 동작하지 않음
그래서 Result로 response, error 모두 반환한 다음 ViewModel에서 switch문으로 Error Handling

2. 10개의 적은 Request Limit을 어떻게 처리할것인가
``` swift
// ViewState에 requestLimit 추가
enum ViewState {
    case idle
    case isLoading
    case requestLimit
}

func checkResult(_ result: Result<[MySection], Error>) -> [MySection] {
        switch result {
        case .success(let mySection):
            return mySection
        case .failure(let error):
            guard let error = error as? NetworkError else {
                print(error.localizedDescription)
                return []
            }
            
// 에러타입이 .requestLimitError이면 viewState를 .requestLimit으로 변경,
// filter로 viewState != .isLoading일때만 스트림 시작
            if error == .requestLimitError {
                viewState = .requestLimit
                currentPage -= 1
                return []
            }
            
            print(error.description)
            return []
        }
    }
```
위 코드설명에는 없지만 viewState != .requestLimit일때 alert창 띄우는것도 추가

## ✅ PR 포인트
뷰의 기능이 점점 많아지면서 input, ouput의 프로퍼티가 아닌 pagination과 같은 transform메소드 밖의 프로퍼티가 많아질꺼라 생각됨  
나중에 한번 적절히 분리하는 방법 생각하기